### PR TITLE
Updates to allow sbt-scrooge to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See [the sbt page on plugins](https://github.com/harrah/xsbt/wiki/Plugins) for
 information on adding plugins. Usually, you need to add the following to your
 `project/plugins.sbt` file:
 
-    addSbtPlugin("com.twitter" % "sbt11-scrooge" % "1.0.0")
+    addSbtPlugin("com.twitter" % "sbt11-scrooge" % "3.0.1-SNAPSHOT")
 
 (But obviously, use the latest version number.)
 
@@ -35,9 +35,9 @@ Here's a working example `project/plugins.sbt`:
 
     resolvers += "twitter-repo" at "http://maven.twttr.com"
     
-    addSbtPlugin("com.twitter" %% "sbt11-scrooge" % "1.0.0")
+    addSbtPlugin("com.twitter" %% "sbt11-scrooge" % "3.0.1-SNAPSHOT")
     
-    addSbtPlugin("com.twitter" %% "sbt-package-dist" % "1.0.0")
+    addSbtPlugin("com.twitter" %% "sbt-package-dist" % "1.0.7")
 
 And `project/Build.scala`:
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.11.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,7 +10,6 @@ resolvers <<= (resolvers) { r =>
   } getOrElse {
     r ++ Seq(
       "twitter.com" at "http://maven.twttr.com/",
-      "scala-tools" at "http://scala-tools.org/repo-releases/",
       "maven" at "http://repo1.maven.org/maven2/",
       "freemarker" at "http://freemarker.sourceforge.net/maven2/"
     )
@@ -20,7 +19,7 @@ resolvers <<= (resolvers) { r =>
 externalResolvers <<= (resolvers) map identity
 
 libraryDependencies <+= (sbtVersion) { sv =>
-  "org.scala-tools.sbt" %% "scripted-plugin" % sv
+  "org.scala-sbt" %% "scripted-plugin" % sv
 }
 
-addSbtPlugin("com.twitter" % "sbt-package-dist" % "1.0.0")
+addSbtPlugin("com.twitter" % "sbt-package-dist" % "1.0.7")


### PR DESCRIPTION
Due to sbt and other updates, sbt-scrooge was not working out of the box.

I pinned it to sbt 0.11.3, fixed org names for the scripted plugin, and upgraded the sbt-package-dist plugin, in addition to updating the README to reflect 3.0.1-SNAPSHOT.
